### PR TITLE
Added errorCallback parameter to webkitGetUserMedia function

### DIFF
--- a/chrome/compare.js
+++ b/chrome/compare.js
@@ -18,7 +18,7 @@
       var video = document.querySelector(that.videoSelector);
       $(that.videoSelector).attr('src', window.URL.createObjectURL(stream));
       $(that.videoSelector).css('display', 'inline-block');
-    });
+    }, that.notifyFail);
   };
 
   client.stopVideo = function() {

--- a/chrome/selfie-base.js
+++ b/chrome/selfie-base.js
@@ -117,7 +117,7 @@ function GitHubSelfies(insertBefore, bodySelector, buttonSelector, videoSelector
       that.stream = stream;
       var video = document.querySelector(that.videoSelector);
       $(that.videoSelector).attr('src', window.URL.createObjectURL(stream));
-    });
+    }, this.notifyFail);
   };
 
   this.stopVideo = function() {


### PR DESCRIPTION
In the latest Chrome canary builds, the third argument to `webkitGetUserMedia` is required, and throws an error if not passed.

![selfie-2](http://i.imgur.com/eiA0BKb.png)
