### PR TITLE
Fixes JavaScript error

### DIFF
--- a/chrome/issues.js
+++ b/chrome/issues.js
@@ -8,7 +8,7 @@
   link.href = chrome.extension.getURL('issues.css');
   link.type = 'text/css';
   link.rel = 'stylesheet';
-  document.documentElement.insertBefore(link);
+  document.documentElement.appendChild(link);
 
   var config = {
       insertBefore : [


### PR DESCRIPTION
I was getting this error in later versions of Chrome:

> Uncaught TypeError: Failed to execute 'insertBefore' on 'Node': 2 arguments required, but only 1 present.

So I just did a quick fix by changing to the `appendChild` function.

Thanks for the great extension!
