### PR TITLE
Move GitHub's markdown help link out of the way during selfies.

### DIFF
--- a/chrome/selfie-base.js
+++ b/chrome/selfie-base.js
@@ -19,10 +19,12 @@ function GitHubSelfieButtons() {
       if (this.videoPreview === null) {
         this.selfieButton.addClass('selected');
         this.showVideoPreview();
+        $('.toolbar-help').hide();
         this.videoPreview.startPreview();
       } else {
         this.videoPreview.destroy();
         this.videoPreview = null;
+        $('.toolbar-help').show();
         this.selfieButton.removeClass('selected');
       }
     });


### PR DESCRIPTION
Github added this "Styling with Markdown is supported" message that makes the selfie window super tiny. Fix it by hiding it when selfies are open.