### PR TITLE
Add permission for imgur

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -14,7 +14,8 @@
   "permissions": [
     "webRequest",
     "webRequestBlocking",
-    "*://github.com/*"
+    "*://github.com/*",
+    "https://api.imgur.com/3/upload"
   ],
 
   "background": {


### PR DESCRIPTION
I get this problem(https://github.com/thieman/github-selfies/issues/87).

I don't know deep knowledge of chrome extension. 
But I think when extension access outer resource, need to add permission for specific url on manifest.

I add permission for `https://api.imgur.com/3/upload` in this PR and it worked for my local test.

I test follow environment.

 * macOS High Sierra 10.13.4
 * Google Chrome 66.0.3359.139（Official Build）
