### PR TITLE
not use URL.createObjectURL for dupricated API

### DIFF
--- a/chrome/selfie-base.js
+++ b/chrome/selfie-base.js
@@ -238,7 +238,7 @@ GitHubSelfieVideoPreview.prototype = {
     getUserMedia({video: true}, (_stream) => {
       this.setMessage('');
       this.stream = _stream;
-      this.videoElem.src = window.URL.createObjectURL(_stream);
+      this.videoElem.srcObject = _stream;
     }, (e) => {
       this.setMessage("You don't have a camera available!");
     });


### PR DESCRIPTION
Use srcObject instead of duplicated API(scheduled).

[Related PR](https://github.com/thieman/github-selfies/pull/91)
>Haha hey @inabajunmr I also just realized from reading that console warning in your GIF that the extension's about to break again in a month (goddammit...). Want to take a proactive stab at that to preserve your work?

# Test result
![test](https://user-images.githubusercontent.com/10000393/40878795-17055a9e-66d1-11e8-9392-cce2abea4239.gif)
