### PR TITLE
Make the allowed paths less strict

### DIFF
--- a/chrome/selfie.js
+++ b/chrome/selfie.js
@@ -28,13 +28,13 @@
 
   var allowedPaths = [
     // New issues
-    /github.com\/[\w\-]+\/[\w\-]+\/issues\/new/,
+    /https:\/\/github.com\/.+?\/.+?\/issues\/new/,
     // Existing issues (comment)
-    /github.com\/[\w\-]+\/[\w\-]+\/issues\/\d+/,
+    /https:\/\/github.com\/.+?\/.+?\/issues\/\d+/,
     // New pull request
-    /github.com\/[\w\-]+\/[\w\-]+\/compare/,
+    /https:\/\/github.com\/.+?\/.+?\/compare/,
     // Existing pull requests (comment)
-    /github.com\/[\w\-]+\/[\w\-]+\/pull\/\d+/
+    /https:\/\/github.com\/.+?\/.+?\/pull\/\d+/
   ];
 
   // Return true if predicate(item) returns true for any item in array.


### PR DESCRIPTION
The current regex is too strict with regards to username and repository name. For example, the selfie button does not show up for `https://github.com/github/scientist.net/issues/new` because of the `.` in `scientist.net`. Also, the regex would try to match sites such as "foogithub.com". Since GitHub requires https and the browser redirects URLs with backslashes to those with forward slashes, it's safe to simplify the regex as I've done here and include the `https://` portion in the regex.