### PR TITLE
Style fixes to make things not look like a garbage fire

### DIFF
--- a/chrome/selfie-base.js
+++ b/chrome/selfie-base.js
@@ -369,6 +369,8 @@ GitHubSelfies.prototype = {
       //ctx.scale(-1, 1);
       ctx.drawImage(video, 0, 0, video.videoWidth, video.videoHeight, 0, 0, video.videoWidth, video.videoHeight);
       imgBinary = canvas.toDataURL('/image/jpeg', 1).split(',')[1];
+      // Hack, canvas is initially hidden before any pictures are taken
+      $(canvas).removeClass('hidden');
       ctx.restore();
       callback(imgBinary);
     };
@@ -440,6 +442,8 @@ GitHubSelfies.prototype = {
           frames.push([ctx.getImageData(0, 0, width, height).data, frameDelay]);
           this.buttons.videoPreview.setProgress(frameNum / totalFrames);
           if (frameNum >= totalFrames) {
+            // Hack, canvas is initially hidden before any pictures are taken
+            $(canvas).removeClass('hidden');
             cancelAnimationFrame(rafRequest);
             makeGif().then(() => this.buttons.videoPreview.setProgress(0));
           }

--- a/chrome/selfie.css
+++ b/chrome/selfie.css
@@ -5,7 +5,22 @@
 .form-actions {
   display: flex;
   flex-direction: row-reverse; /* simulate their float: right */
+  flex-wrap: wrap;
   align-items: flex-start;
+}
+
+/*
+  Trying to get the "Styling with Markdown is supported"
+  block to not push the flex container to the right.
+  There's almost certainly a better way, please replace
+  this if you figure it out.
+*/
+.js-suggester-container > .float-left {
+  position: absolute;
+}
+
+.hidden {
+  display: none;
 }
 
 #selfieControls {
@@ -33,8 +48,11 @@
 .selfieVideoContainer {
   position: relative;
   flex: 1; /* Take available space */
+  flex-basis: 100%;
+  width: 100%;
   vertical-align: top;
   margin-right: 8px;
+  margin-top: 8px;
 }
 
 .selfieProgressContainer {


### PR DESCRIPTION
@Haacked 

1. Get the selfie container to take up the full width of the comment box again
2. Hide the last-snapshot container until we take a picture for the first time. Goal here was to eliminate the extra vertical padding before ever taking a picture, but there's probably a more elegant way to achieve this
3. At least two hacks I'm probably gonna get yelled at for

Some margins are still slightly off but this is much improved.

My ugly mug for proof:

![image](https://user-images.githubusercontent.com/1414305/50541451-3e3fef00-0b74-11e9-8033-535cca55901f.png)
