### PR TITLE
Update imgur upload route

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -15,7 +15,7 @@
     "webRequest",
     "webRequestBlocking",
     "*://github.com/*",
-    "https://api.imgur.com/3/upload"
+    "https://api.imgur.com/3/image"
   ],
 
   "background": {

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "GitHub Selfies",
   "description": "Selfies! For GitHub! Hooray!",
-  "version": "2.0.6",
+  "version": "2.0.7",
 
   "icons": {
     "16": "icon16.png",

--- a/chrome/selfie-base.js
+++ b/chrome/selfie-base.js
@@ -456,7 +456,7 @@ GitHubSelfies.prototype = {
 
   uploadSelfie: function(imageData, successCb, errorCb) {
     $.ajax({
-      url  : 'https://api.imgur.com/3/upload',
+      url  : 'https://api.imgur.com/3/image',
       type : 'POST',
       beforeSend: (xhr) => {
         xhr.setRequestHeader('Authorization', 'Client-ID ' + this.clientId);


### PR DESCRIPTION
imgur lists `/upload` as an alternative route for POST, but `/image` as the main one. I was getting the CORB error before, but this fixed it for me.